### PR TITLE
Fix: PulseStandard error with single followed metric

### DIFF
--- a/src/client/components/analytics/PulseStandard.tsx
+++ b/src/client/components/analytics/PulseStandard.tsx
@@ -14,7 +14,7 @@ const PulseStandard: React.FC<{
 
   } else {
 
-    const pulseUrl = (banInsights && banInsights[1].metricDefinition.url) ?? '';
+    const pulseUrl = (banInsights && banInsights[0]?.metricDefinition?.url) ?? '';
 
     return (
       <>


### PR DESCRIPTION
Hi team.
This fixes an issue in the PulseStandard component where an error occurs if only one metric is being followed in Tableau Pulse.  
The fix sets the banInsights index to 0 to handle this case properly.